### PR TITLE
SRE-1182 Removing the zip file extention

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN curl -s https://api.github.com/repos/nobl9/sloctl/releases/latest | \
   grep "browser_download_url.*linux*" | \
   cut -d : -f 2,3 | \
   tr -d \" | \
-  wget -O sloctl.zip -qi -
+  wget -O sloctl -qi -
 
-# unzip and place the binary in the PATH
-RUN unzip sloctl.zip && mv sloctl /usr/local/bin
+# place the binary in the PATH
+RUN chmod +x sloctl
+RUN mv sloctl /usr/local/bin
 
 # Copy over our entrypoint file
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
The `sloctl` releases were changed, and the zip file extension was removed.  This reflects that change, and removes it in the installation process