### PR TITLE
update version of action in example yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - uses: nobl9/nobl9-action@v0.2.0
+      - uses: nobl9/nobl9-action@v0.2.1
         with:
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}


### PR DESCRIPTION
A user was struggling with an break that turned out to be a version issue, which they hit due to copy paste of the example yaml with this stale version in it.