### PR TITLE
Support multiple sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This action applies a Nobl9 configuration file (specified via the sloctl_yml inp
 | --- | --- | --- | --- |
 | `client_id` | The Client ID of your Nobl9 account | **Yes** | N/A |
 | `client_secret` | The Client Secret of your Nobl9 account | **Yes** | N/A |
-| `sloctl_yml` | The path or [glob pattern](https://pkg.go.dev/path/filepath#Match) to the configuration in YAML format, relative to the root directory of the repository | **Yes** | N/A |
+| `sloctl_yml` | The path or [glob pattern](https://pkg.go.dev/path/filepath#Match) to the configuration in YAML format, relative to the root directory of the repository. In order to supply multiple sources, separate them with comma (example below) | **Yes** | N/A |
 | `dry_run` | Submits server-side request without persisting the configured resources | No | `false` |
 
 ## Example Usage
@@ -34,7 +34,7 @@ jobs:
           sloctl_yml: "slos.yaml"
 ```
 
-### Apply multiple files
+### Recursively apply multiple files using glob pattern
 ```yaml
 name: Nobl9 GitHub Actions Demo
 on: [push]
@@ -49,6 +49,23 @@ jobs:
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           sloctl_yml: "**"
+```
+
+### Apply from multiple sources
+```yaml
+name: Nobl9 GitHub Actions Demo
+on: [push]
+jobs:
+  nobl9:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - uses: nobl9/nobl9-action@v0.2.2
+        with:
+          client_id: ${{ secrets.CLIENT_ID }}
+          client_secret: ${{ secrets.CLIENT_SECRET }}
+          sloctl_yml: "my slo1.yaml,my-slo2.yml,dir/my-slo3.json"
 ```
 
 ### Dry run

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,10 +11,16 @@ defaultContext = "default"
     clientSecret = "${INPUT_CLIENT_SECRET}"
 EOF
 
-flags=(
-  -y # Required to auto confirm, for more details refer to: https://docs.nobl9.com/sloctl-user-guide?_highlight=prompt&_highlight=threshold#apply
-  -f "${INPUT_SLOCTL_YML}"
-)
+# Required to auto confirm, for more details refer to:
+# https://docs.nobl9.com/sloctl-user-guide?_highlight=prompt&_highlight=threshold#apply
+flags=(-y)
+
+# INPUT_SLOCTL_YML should be a comma separated values string to avoid issues
+# with file paths containing spaces.
+IFS=","
+for filepath in $INPUT_SLOCTL_YML; do
+  flags+=(-f "$filepath")
+done
 
 if [[ $INPUT_DRY_RUN == "true" ]]; then
   flags+=(--dry-run)


### PR DESCRIPTION
This PR adds support for multiple definitions sources.
We can now supply the action with, for example, multiple directories to read from.
In order to achieve that with backwards compatibility and support of spaces in file names, each next source must be provided after a comma.